### PR TITLE
Fix ReferenceError: getTodoList is not defined

### DIFF
--- a/initialise.js
+++ b/initialise.js
@@ -11,6 +11,7 @@ const {
 const { getContributionScores } = require("./functions/contribscores.js");
 const {
     addTodoTask,
+    getTodoList,
     buildTodoListContainer,
     updateTasks,
     buildTickModal


### PR DESCRIPTION
This pull request fixes a `ReferenceError: getTodoList is not defined` in `initialise.js`.

The issue was caused by calling `getTodoList` in the `interactionCreate` event handler without importing it from the `todolist.js` utility module.

Changes:
- Added `getTodoList` to the destructuring import in `initialise.js`.
- Verified that `functions/todolist.js` correctly exports `getTodoList`.
- Verified the syntax of `initialise.js` using `node --check`.
- Verified the functionality of the todo module with a temporary test script.
- Cleaned up all temporary files before submission.

---
*PR created automatically by Jules for task [8039239113187865563](https://jules.google.com/task/8039239113187865563) started by @whostacking*