### PR TITLE
Fix and improve wiki search autocomplete functionality

### DIFF
--- a/initialise.js
+++ b/initialise.js
@@ -75,7 +75,10 @@ async function fetchWikiChoices(wikiConfig, params, listKey, isFileSearch) {
             headers: { "User-Agent": "DiscordBot/Orbital" },
             signal: AbortSignal.timeout(3000)
         });
-        if (!res.ok) return [];
+        if (!res.ok) {
+            console.warn(`Wiki API returned ${res.status} for ${listKey} (${wikiConfig.apiEndpoint})`);
+            return [];
+        }
 
         const json = await res.json();
         const items = json.query?.[listKey] || [];


### PR DESCRIPTION
The wiki search autocomplete was reported as buggy and case-sensitive, making it difficult to find files like "Gearshock Beach landscape.png" on the A Block's Journey wiki. The issue was primarily due to the use of `srwhat=title` in `list=search`, which is often unreliable or disabled on wikis in 'miser mode'.

This PR addresses the issue by:
1.  **Using `prefixsearch`**: This MediaWiki API module is specifically designed for autocomplete and is natively case-insensitive, providing a much better experience as the user types.
2.  **Using `intitle:` in `srsearch`**: For "similar search" (finding terms anywhere in the title), we now use the `intitle:` prefix within the standard search query. This is the recommended approach for wikis where `srwhat=title` might be restricted.
3.  **Refactoring**: Centralized the result processing into a `fetchWikiChoices` function to handle the different response structures of various MediaWiki API modules.
4.  **Merging & Deduplicating**: Results from both `prefixsearch` and `search` are merged and deduplicated to provide the most relevant choices while adhering to Discord's 25-item limit.

---
*PR created automatically by Jules for task [11373983488654011306](https://jules.google.com/task/11373983488654011306) started by @whostacking*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified autocomplete flow that centralizes fetching, runs parallel queries for non-empty input, and trims long titles to improve suggestion quality.
  * Consistent handling for file-prefixed queries and an empty-input fallback for list-based suggestions.

* **Bug Fixes**
  * Deduplicated and capped suggestions (25) with improved error handling and a 3s fetch timeout to return predictable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->