### PR TITLE
Update gallery video extraction logic

### DIFF
--- a/functions/parse_page.js
+++ b/functions/parse_page.js
@@ -353,7 +353,8 @@ async function getSectionContent(pageTitle, sectionName, wikiConfig) {
         $('ul.gallery .gallerybox').each((i, el) => {
             const $el = $(el);
             const img = $el.find('img').first();
-            let src = img.attr('src');
+            const video = $el.find('video').first();
+            let src = img.attr('src') || video.attr('src') || video.find('source').first().attr('src');
 
             if (src) {
                 if (src.startsWith('//')) src = 'https:' + src;


### PR DESCRIPTION
The gallery parsing logic was previously only looking for `<img>` tags to populate the Media Gallery. This update adds support for `<video>` tags, which are used by some MediaWiki extensions for local video embedding. The logic now checks for an `<img>` tag first, then falls back to the `src` of a `<video>` tag, and finally the `src` of the first `<source>` element within a `<video>` tag.

---
*PR created automatically by Jules for task [18000382026401476120](https://jules.google.com/task/18000382026401476120) started by @whostacking*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gallery now supports video content with automatic format detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->