### PR TITLE
Refactor /wiki and add /parse commands

### DIFF
--- a/functions/commands.js
+++ b/functions/commands.js
@@ -21,28 +21,62 @@ const commands = [
     },
     {
         name: 'wiki',
-        description: 'Get a link to a wiki or search for a page/file',
+        description: 'Get a link to a wiki',
         options: [
             {
                 name: 'wiki',
-                description: 'The wiki to link to or search in',
+                description: 'The wiki to link to',
                 type: 3, // STRING
                 required: true,
                 choices: wikiChoices
-            },
+            }
+        ]
+    },
+    {
+        name: 'parse',
+        description: 'Search for a page or file on a wiki',
+        options: [
             {
                 name: 'page',
                 description: 'Search for a wiki page',
-                type: 3, // STRING
-                required: false,
-                autocomplete: true
+                type: 1, // SUB_COMMAND
+                options: [
+                    {
+                        name: 'wiki',
+                        description: 'The wiki to search in',
+                        type: 3, // STRING
+                        required: true,
+                        choices: wikiChoices
+                    },
+                    {
+                        name: 'page',
+                        description: 'The page to search for',
+                        type: 3, // STRING
+                        required: true,
+                        autocomplete: true
+                    }
+                ]
             },
             {
                 name: 'file',
-                description: 'Search for a wiki file (provide only page OR file)',
-                type: 3, // STRING
-                required: false,
-                autocomplete: true
+                description: 'Search for a wiki file',
+                type: 1, // SUB_COMMAND
+                options: [
+                    {
+                        name: 'wiki',
+                        description: 'The wiki to search in',
+                        type: 3, // STRING
+                        required: true,
+                        choices: wikiChoices
+                    },
+                    {
+                        name: 'file',
+                        description: 'The file to search for',
+                        type: 3, // STRING
+                        required: true,
+                        autocomplete: true
+                    }
+                ]
             }
         ]
     }


### PR DESCRIPTION
I have refactored the `/wiki` command and introduced a new `/parse` command as requested.

### Changes Made:

1.  **Redefined `/wiki` command**:
    *   Simplified the command to only accept a `wiki` parameter.
    *   The command now outputs only the direct base URL of the selected wiki.
    *   Removed the `MessageFlags.IsComponentsV2` flag and the welcome embed to ensure it's a plain link response.

2.  **Introduced `/parse` command**:
    *   Added `/parse` with two sub-commands: `page` and `file`.
    *   Each sub-command takes a `wiki` parameter and a search term (`page` or `file`).
    *   This provides a cleaner interface and strictly enforces mutually exclusive search types.

3.  **Updated Autocomplete Handling**:
    *   Updated the interaction logic to support autocomplete for the new `/parse page` and `/parse file` sub-commands.
    *   Maintained the existing efficient search logic using MediaWiki's API.

4.  **Updated Interaction Logic**:
    *   Refactored `handleInteraction` in `functions/interactions.js` to route the new command structure correctly.
    *   Ensured that bot messages are still tracked in `botToAuthorMap` for wastebasket (deletion) functionality.

These changes improve the bot's command structure by separating direct linking from content parsing, aligning with the user's request for a simpler `/wiki` output and dedicated `/parse` functionality.

---
*PR created automatically by Jules for task [17268634036407381069](https://jules.google.com/task/17268634036407381069) started by @whostacking*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new parse command to search for specific pages or files across wikis.

* **Changes**
  * Refined the wiki command to provide wiki links only with clearer descriptions. Page and file search functionality has been moved to the dedicated parse command for improved organization and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->