### PR TITLE
Fix SectionBuilder Validation Error

### DIFF
--- a/functions/interactions.js
+++ b/functions/interactions.js
@@ -147,11 +147,7 @@ function buildPageEmbed(title, content, imageUrl, wikiConfig, gallery = null) {
             const fallbackImage = "https://upload.wikimedia.org/wikipedia/commons/8/89/HD_transparent_picture.png";
             const finalImageUrl = (!hasGallery && typeof imageUrl === "string" && imageUrl.trim() !== "") ? imageUrl : fallbackImage;
 
-            try {
-                mainSection.setThumbnailAccessory(thumbnail => thumbnail.setURL(finalImageUrl));
-            } catch (err) {
-                console.warn("Failed to set thumbnail accessory:", err.message);
-            }
+            mainSection.setThumbnailAccessory(thumbnail => thumbnail.setURL(finalImageUrl));
 
             container.addSectionComponents(mainSection);
         }

--- a/functions/speedrun.js
+++ b/functions/speedrun.js
@@ -98,6 +98,7 @@ async function handleSpeedrunRequest(interaction, gameKey, categoryId, levelId =
         const container = new ContainerBuilder();
         const section = new SectionBuilder();
         section.addTextDisplayComponents([new TextDisplayBuilder().setContent(description)]);
+        section.setThumbnailAccessory(thumbnail => thumbnail.setURL("https://upload.wikimedia.org/wikipedia/commons/8/89/HD_transparent_picture.png"));
 
         const row = new ActionRowBuilder();
         row.addComponents(


### PR DESCRIPTION
This change fixes a `CombinedError` validation failure in `discord.js`'s `SectionBuilder`. By ensuring every `SectionBuilder` has a thumbnail accessory (using a transparent PNG fallback where necessary), we satisfy the mandatory component requirement for 'Components V2' layouts. This specifically fixes the speedrun leaderboard command and strengthens the wiki page parsing logic.

---
*PR created automatically by Jules for task [18019323959094352036](https://jules.google.com/task/18019323959094352036) started by @whostacking*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added thumbnail image display to the previously built section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->