### PR TITLE
Integrate Superstar Racers Recode V13 and restructure parameters

### DIFF
--- a/functions/commands.js
+++ b/functions/commands.js
@@ -2,7 +2,8 @@ const { WIKIS } = require("../config.js");
 const {
     SB64_CATEGORIES,
     SB64_CHARACTER_CHOICES,
-    SR_CATEGORIES,
+    SR_FILTER_CHOICES,
+    SR_VERSION_CHOICES,
     SR_LEVELS,
     SR_EVENTS_CHOICES,
     SB64_CATEGORY_IDS,
@@ -10,8 +11,6 @@ const {
     SB64_VARIABLES,
     SB64_DEFAULTS,
     SR_CATEGORY_IDS,
-    SR_ALL_MAPS_V12_VALUE,
-    SR_ALL_MAPS_LOBBY_VALUE,
     SR_VARIABLES,
     SR_DEFAULTS,
     ABJ_CATEGORIES
@@ -62,15 +61,22 @@ const commands = [
                 type: 1, // SUB_COMMAND
                 options: [
                     {
-                        name: 'category',
-                        description: 'The category to view',
+                        name: 'filter',
+                        description: 'The filter to apply',
                         type: 3, // STRING
                         required: true,
-                        choices: SR_CATEGORIES
+                        choices: SR_FILTER_CHOICES
+                    },
+                    {
+                        name: 'version',
+                        description: 'The version to view',
+                        type: 3, // STRING
+                        required: true,
+                        choices: SR_VERSION_CHOICES
                     },
                     {
                         name: 'level',
-                        description: 'The level to view (only works with Individual Levels categories)',
+                        description: 'The level to view (only works with Individual map filter)',
                         type: 3, // STRING
                         required: false,
                         choices: SR_LEVELS
@@ -196,8 +202,8 @@ module.exports = {
     SB64_VARIABLES,
     SB64_DEFAULTS,
     SR_CATEGORY_IDS,
-    SR_ALL_MAPS_V12_VALUE,
-    SR_ALL_MAPS_LOBBY_VALUE,
+    SR_FILTER_CHOICES,
+    SR_VERSION_CHOICES,
     SR_VARIABLES,
     SR_DEFAULTS
 };

--- a/functions/interactions.js
+++ b/functions/interactions.js
@@ -10,8 +10,6 @@ const {
     SB64_VARIABLES,
     SB64_DEFAULTS,
     SR_CATEGORY_IDS,
-    SR_ALL_MAPS_V12_VALUE,
-    SR_ALL_MAPS_LOBBY_VALUE,
     SR_VARIABLES,
     SR_DEFAULTS
 } = require("./speedrun.js");
@@ -400,26 +398,42 @@ async function handleInteraction(interaction) {
 
                 response = await handleSpeedrunRequest(interaction, 'sb64', categoryId, null, variables);
             } else if (subCommand === 'sr') {
-                let categoryId = interaction.options.getString('category');
+                const filter = interaction.options.getString('filter');
+                const version = interaction.options.getString('version');
                 let levelId = interaction.options.getString('level');
                 const events = interaction.options.getString('events') || SR_DEFAULTS.EVENTS; // Default to No Events
 
                 const variables = {};
                 variables[SR_VARIABLES.EVENTS] = events;
 
-                // Handle custom All Maps category choices
-                if (categoryId === SR_ALL_MAPS_V12_VALUE) {
+                let categoryId;
+                if (filter === 'individual_map') {
+                    if (!levelId) {
+                        return interaction.reply({ content: 'You must select a level when using the "Individual map" filter.', ephemeral: true });
+                    }
+                    if (version === 'v13') {
+                        categoryId = SR_CATEGORY_IDS.INDIVIDUAL_LEVELS_V13;
+                    } else if (version === 'v12') {
+                        categoryId = SR_CATEGORY_IDS.INDIVIDUAL_LEVELS_V12;
+                    } else if (version === 'v10') {
+                        categoryId = SR_CATEGORY_IDS.INDIVIDUAL_LEVELS_V10;
+                    }
+                } else {
+                    // Full game or Full game with lobby
                     categoryId = SR_CATEGORY_IDS.ALL_MAPS;
-                    variables[SR_VARIABLES.VERSIONS] = SR_DEFAULTS.VERSION_V12;
                     levelId = null; // Ensure levelId is cleared for full-game categories
-                } else if (categoryId === SR_ALL_MAPS_LOBBY_VALUE) {
-                    categoryId = SR_CATEGORY_IDS.ALL_MAPS;
-                    variables[SR_VARIABLES.VERSIONS] = SR_DEFAULTS.VERSION_LOBBY;
-                    levelId = null; // Ensure levelId is cleared for full-game categories
-                } else if (categoryId === SR_CATEGORY_IDS.ALL_MAPS) {
-                    // Fallback for direct ID or old values, default to V12
-                    variables[SR_VARIABLES.VERSIONS] = SR_DEFAULTS.VERSION_V12;
-                    levelId = null; // Ensure levelId is cleared for full-game categories
+
+                    if (filter === 'full_game_lobby') {
+                        variables[SR_VARIABLES.VERSIONS] = SR_DEFAULTS.VERSION_LOBBY;
+                    } else {
+                        if (version === 'v13') {
+                            variables[SR_VARIABLES.VERSIONS] = SR_DEFAULTS.VERSION_V13;
+                        } else if (version === 'v12') {
+                            variables[SR_VARIABLES.VERSIONS] = SR_DEFAULTS.VERSION_V12;
+                        } else if (version === 'v10') {
+                            variables[SR_VARIABLES.VERSIONS] = SR_DEFAULTS.VERSION_V11; // Map V10 to V11 for full game
+                        }
+                    }
                 }
 
                 response = await handleSpeedrunRequest(interaction, 'sr', categoryId, levelId, variables);

--- a/functions/speedrun.js
+++ b/functions/speedrun.js
@@ -44,18 +44,21 @@ const SB64_CHARACTER_CHOICES = [
 
 const SR_CATEGORY_IDS = {
     ALL_MAPS: 'rkl63l6k',
-    INDIVIDUAL_LEVELS_RECODE: '9d8qwwwd',
-    INDIVIDUAL_LEVELS_LEGACY: 'xd1yxxzd'
+    INDIVIDUAL_LEVELS_V13: 'xk94rvxd',
+    INDIVIDUAL_LEVELS_V12: '9d8qwwwd',
+    INDIVIDUAL_LEVELS_V10: 'xd1yxxzd'
 };
 
-const SR_ALL_MAPS_V12_VALUE = 'sr_all_maps_v12';
-const SR_ALL_MAPS_LOBBY_VALUE = 'sr_all_maps_lobby';
+const SR_FILTER_CHOICES = [
+    { name: 'Full game', value: 'full_game' },
+    { name: 'Full game with lobby', value: 'full_game_lobby' },
+    { name: 'Individual map', value: 'individual_map' }
+];
 
-const SR_CATEGORIES = [
-    { name: 'All maps', value: SR_ALL_MAPS_V12_VALUE },
-    { name: 'All maps (Lobby)', value: SR_ALL_MAPS_LOBBY_VALUE },
-    { name: 'Individual Recode maps', value: SR_CATEGORY_IDS.INDIVIDUAL_LEVELS_RECODE },
-    { name: 'Individual pre-rewrite maps', value: SR_CATEGORY_IDS.INDIVIDUAL_LEVELS_LEGACY }
+const SR_VERSION_CHOICES = [
+    { name: 'Pre-Recode (V10)', value: 'v10' },
+    { name: 'Legacy Recode (V12)', value: 'v12' },
+    { name: 'Recode (V13)', value: 'v13' }
 ];
 
 const SR_LEVEL_IDS = {
@@ -77,6 +80,7 @@ const SR_LEVEL_IDS = {
     SWEET_SPEEDWAY: '9gy37kk9',
     UNDERWATER_HIGHWAY: '9x1lxm1d',
     WINTER_WONDERLAND: '9gy3vpj9',
+    TUTORIAL: 'd7yve1gd',
     LOBBY_EASY: 'wj75z50w',
     LOBBY_MEDIUM: 'wo7060j9',
     LOBBY_HARD: 'd1j727zd'
@@ -101,6 +105,7 @@ const SR_LEVELS = [
     { name: 'Sweet Speedway', value: SR_LEVEL_IDS.SWEET_SPEEDWAY },
     { name: 'Underwater Highway', value: SR_LEVEL_IDS.UNDERWATER_HIGHWAY },
     { name: 'Winter Wonderland', value: SR_LEVEL_IDS.WINTER_WONDERLAND },
+    { name: 'Tutorial', value: SR_LEVEL_IDS.TUTORIAL },
     { name: 'Lobby Easy Time Trial', value: SR_LEVEL_IDS.LOBBY_EASY },
     { name: 'Lobby Medium Time Trial', value: SR_LEVEL_IDS.LOBBY_MEDIUM },
     { name: 'Lobby Hard Time Trial', value: SR_LEVEL_IDS.LOBBY_HARD }
@@ -125,7 +130,9 @@ const SB64_DEFAULTS = {
 
 const SR_DEFAULTS = {
     EVENTS: 'qkem56nq',
+    VERSION_V13: 'qox9wdxq',
     VERSION_V12: 'ln8w8p0l',
+    VERSION_V11: 'lmojmn81',
     VERSION_LOBBY: '12vm002q'
 };
 
@@ -343,9 +350,8 @@ module.exports = {
     SB64_VARIABLES,
     SB64_CHARACTER_CHOICES,
     SR_CATEGORY_IDS,
-    SR_ALL_MAPS_V12_VALUE,
-    SR_ALL_MAPS_LOBBY_VALUE,
-    SR_CATEGORIES,
+    SR_FILTER_CHOICES,
+    SR_VERSION_CHOICES,
     SR_LEVEL_IDS,
     SR_LEVELS,
     SR_VARIABLES,


### PR DESCRIPTION
This PR integrates the new Superstar Racers Recode (V13) leaderboard categories and restructures the `/lbspeedrun sr` command parameters to improve usability and accommodate new game versions.

Key changes:
- Replaced the `category` parameter with `filter` and `version` in `/lbspeedrun sr`.
- Added support for Recode (V13), Legacy Recode (V12), and Pre-Recode (V10) across both full-game and individual map leaderboards.
- Included the new "Tutorial" level in the individual map options.
- Implemented robust mapping logic in `functions/interactions.js` to route requests to the correct Speedrun.com category IDs and version variables.
- Added an ephemeral error message to prompt users for a level when the "Individual map" filter is selected without one.
- Centralized new constants and choices in `functions/speedrun.js` and updated re-exports in `functions/commands.js`.

---
*PR created automatically by Jules for task [6650298796988513389](https://jules.google.com/task/6650298796988513389) started by @whostacking*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added filter and version selection options for speedrun leaderboard queries.
  * Extended speedrun version support (V10, V12, V13) and added "Tutorial" level.

* **Changes**
  * Speedrun leaderboard command now requires filter and version parameters for improved flexibility in data selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->