### PR TITLE
Limit wiki embeds to two paragraphs

### DIFF
--- a/functions/interactions.js
+++ b/functions/interactions.js
@@ -17,7 +17,7 @@ const {
     WIKIS,
     toggleContribScore
 } = require("../config.js");
-const { fetch, truncateToParagraphs } = require("./utils.js");
+const { fetch, truncateToParagraphs: truncateContentToParagraphs } = require("./utils.js");
 
 const {
     ContainerBuilder,
@@ -317,7 +317,7 @@ async function handleUserRequest(wikiConfig, rawPageName, messageOrInteraction, 
                 content = "No content available.";
             }
 
-            const container = buildPageEmbed(displayTitle, truncateToParagraphs(content), imageUrl, wikiConfig, gallery);
+            const container = buildPageEmbed(displayTitle, truncateContentToParagraphs(content), imageUrl, wikiConfig, gallery);
 
             return await smartReply({
                 content: "",

--- a/functions/interactions.js
+++ b/functions/interactions.js
@@ -17,7 +17,7 @@ const {
     WIKIS,
     toggleContribScore
 } = require("../config.js");
-const { fetch } = require("./utils.js");
+const { fetch, truncateToParagraphs } = require("./utils.js");
 
 const {
     ContainerBuilder,
@@ -317,7 +317,7 @@ async function handleUserRequest(wikiConfig, rawPageName, messageOrInteraction, 
                 content = "No content available.";
             }
 
-            const container = buildPageEmbed(displayTitle, content.slice(0, 1000), imageUrl, wikiConfig, gallery);
+            const container = buildPageEmbed(displayTitle, truncateToParagraphs(content), imageUrl, wikiConfig, gallery);
 
             return await smartReply({
                 content: "",

--- a/functions/parse_page.js
+++ b/functions/parse_page.js
@@ -1,4 +1,4 @@
-const { fetch, truncateToParagraphs } = require("./utils.js");
+const { fetch, truncateToParagraphs: truncateContentToParagraphs } = require("./utils.js");  
 const cheerio = require('cheerio');
 
 // --- CACHING ---
@@ -99,12 +99,12 @@ function htmlToMarkdown(html, baseUrl, $existing = null) {
             }
             case 'h1':
             case 'h2':
-                return childrenContent.trim() ? `## ${childrenContent.trim()}\n\n` : '';
+                return childrenContent.trim() ? `## ${childrenContent.trim()}\n` : '';
             case 'h3':
             case 'h4':
             case 'h5':
             case 'h6':
-                return childrenContent.trim() ? `### ${childrenContent.trim()}\n\n` : '';
+                return childrenContent.trim() ? `### ${childrenContent.trim()}\n` : '';
             default:
                 return childrenContent;
         }
@@ -496,7 +496,7 @@ async function parseTemplates(text, wikiConfig) {
             const anchor = fragment ? `#${encodeURIComponent(fragment.replace(/ /g, "_"))}` : '';
             const link = `<${wikiConfig.articlePath}${parts.join(':')}${anchor}>`;
 
-            replacement = `**${templateName}** → ${truncateToParagraphs(actualText)}\n${link}`;
+            replacement = `**${templateName}** → ${truncateContentToParagraphs(actualText)}\n${link}`;
         } else {
             replacement = "I don't know.";
         }

--- a/functions/parse_page.js
+++ b/functions/parse_page.js
@@ -1,4 +1,4 @@
-const { fetch } = require("./utils.js");
+const { fetch, truncateToParagraphs } = require("./utils.js");
 const cheerio = require('cheerio');
 
 // --- CACHING ---
@@ -86,22 +86,25 @@ function htmlToMarkdown(html, baseUrl, $existing = null) {
                 return '\n';
             case 'p':
             case 'div':
+                return `${childrenContent}\n\n`;
+            case 'ul':
+            case 'ol':
                 return `${childrenContent}\n`;
             case 'li': {
                 const isOrdered = node.parent && node.parent.name === 'ol';
                 const prefix = isOrdered
                     ? `${Array.from(node.parent.children).filter(c => c.name === 'li').indexOf(node) + 1}. `
                     : '* ';
-                return `${prefix}${childrenContent.trim()}`;
+                return `${prefix}${childrenContent.trim()}\n`;
             }
             case 'h1':
             case 'h2':
-                return childrenContent.trim() ? `## ${childrenContent.trim()}\n` : '';
+                return childrenContent.trim() ? `## ${childrenContent.trim()}\n\n` : '';
             case 'h3':
             case 'h4':
             case 'h5':
             case 'h6':
-                return childrenContent.trim() ? `### ${childrenContent.trim()}\n` : '';
+                return childrenContent.trim() ? `### ${childrenContent.trim()}\n\n` : '';
             default:
                 return childrenContent;
         }
@@ -493,7 +496,7 @@ async function parseTemplates(text, wikiConfig) {
             const anchor = fragment ? `#${encodeURIComponent(fragment.replace(/ /g, "_"))}` : '';
             const link = `<${wikiConfig.articlePath}${parts.join(':')}${anchor}>`;
 
-            replacement = `**${templateName}** → ${actualText.slice(0,1000)}\n${link}`;
+            replacement = `**${templateName}** → ${truncateToParagraphs(actualText)}\n${link}`;
         } else {
             replacement = "I don't know.";
         }

--- a/functions/utils.js
+++ b/functions/utils.js
@@ -21,4 +21,18 @@ const fetch = async (...args) => {
     return fetchInstance(urlOrRequest, newOptions);
 };
 
-module.exports = { fetch };
+/**
+ * Truncates a markdown string to a certain number of paragraphs.
+ * Paragraphs are assumed to be separated by double newlines (\n\n).
+ * @param {string} text - The markdown text to truncate.
+ * @param {number} maxParagraphs - Maximum number of paragraphs to keep.
+ * @returns {string} - The truncated text.
+ */
+function truncateToParagraphs(text, maxParagraphs = 2) {
+    if (!text) return "";
+    const paragraphs = text.split(/\n\n+/).filter(p => p.trim().length > 0);
+    if (paragraphs.length <= maxParagraphs) return text;
+    return paragraphs.slice(0, maxParagraphs).join('\n\n') + ' ...';
+}
+
+module.exports = { fetch, truncateToParagraphs };

--- a/functions/utils.js
+++ b/functions/utils.js
@@ -31,8 +31,32 @@ const fetch = async (...args) => {
 function truncateToParagraphs(text, maxParagraphs = 2) {
     if (!text) return "";
     const paragraphs = text.split(/\n\n+/).filter(p => p.trim().length > 0);
-    if (paragraphs.length <= maxParagraphs) return text;
-    return paragraphs.slice(0, maxParagraphs).join('\n\n') + ' ...';
+
+    let result;
+    if (paragraphs.length <= maxParagraphs) {
+        result = text;
+    } else {
+        result = paragraphs.slice(0, maxParagraphs).join('\n\n') + ' ...';
+    }
+
+    // Ensure the result doesn't exceed Discord's 2000 character limit
+    if (result.length > 2000) {
+        // Try to truncate at paragraph boundaries
+        let truncated = "";
+        for (const para of paragraphs) {
+            const testResult = truncated ? truncated + '\n\n' + para : para;
+            if (testResult.length + 4 > 2000) break; // +4 for ' ...'
+            truncated = testResult;
+        }
+        result = truncated + ' ...';
+
+        // If still too long, hard truncate
+        if (result.length > 2000) {
+            result = result.substring(0, 1997) + '...';
+        }
+    }
+
+    return result;
 }
 
 module.exports = { fetch, truncateToParagraphs };


### PR DESCRIPTION
This PR implements paragraph-based truncation for wiki embeds. Instead of a hard 1000-character limit, content is now limited to the first two paragraphs (delimited by double newlines). This ensures that the lead section is displayed gracefully and fits within Discord's message limits.

Key changes:
- **`functions/parse_page.js`**: `htmlToMarkdown` now ensures block-level elements (`p`, `div`, headers) are followed by `\n\n`.
- **`functions/utils.js`**: Added `truncateToParagraphs` helper.
- **`functions/interactions.js`**: `handleUserRequest` now uses the new truncation logic.
- **`functions/parse_page.js`**: `parseTemplates` now uses the new truncation logic.

---
*PR created automatically by Jules for task [9632092824062990037](https://jules.google.com/task/9632092824062990037) started by @whostacking*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved content previews and template/embedded extract text to truncate at natural paragraph boundaries, with more readable ellipses and fewer mid-sentence cutoffs.
  * Refined markdown rendering for cleaner spacing after paragraphs/blocks and consistent line breaks for list items.
* **Documentation**
  * Enhanced markdown rendering output for improved readability in rendered content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->