### PR TITLE
💧 improvement(embedding): Add namespace shortcuts mw: and t:

### DIFF
--- a/initialise.js
+++ b/initialise.js
@@ -72,7 +72,7 @@ function getWikiAndPage(messageContent, channelParentId) {
     if (!match) return null;
 
     const prefix = match[1] || match[3];
-    const rawPageName = (match[2] || match[4]).trim();
+    let rawPageName = (match[2] || match[4]).trim();
 
     let wikiConfig = null;
     if (prefix) {
@@ -80,6 +80,13 @@ function getWikiAndPage(messageContent, channelParentId) {
     } else {
         const wikiKey = CATEGORY_WIKI_MAP[channelParentId] || "superstar-racers";
         wikiConfig = WIKIS[wikiKey];
+    }
+
+    const rawLower = rawPageName.toLowerCase();
+    if (rawLower.startsWith("mw:")) {
+        rawPageName = "MediaWiki:" + rawPageName.slice(3).trim();
+    } else if (rawLower.startsWith("t:")) {
+        rawPageName = "Template:" + rawPageName.slice(2).trim();
     }
 
     return { wikiConfig, rawPageName };


### PR DESCRIPTION
Add MediaWiki namespace shortcuts mw: (resolves to MediaWiki:) and Template namespace shortcuts t: (resolves to Template:) in message embedding syntax, including wiki-exclusive support.

---
*PR created automatically by Jules for task [10340050824274350242](https://jules.google.com/task/10340050824274350242) started by @whostacking*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wiki page resolution by recognizing shorthand `mw:` and `t:` namespace prefixes.
  * Shorthand prefixes are now correctly expanded to `MediaWiki:` and `Template:` page namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->